### PR TITLE
Tweak codes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,137 @@
 .idea/
 /results/
 /.venv/
+
+envs/
+ray_results/
+.vscode/
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/

--- a/MADDPG.py
+++ b/MADDPG.py
@@ -137,4 +137,5 @@ class MADDPG:
         data = torch.load(file)
         for agent_id, agent in instance.agents.items():
             agent.actor.load_state_dict(data[agent_id])
+            # agent.actor.eval() # https://tutorials.pytorch.kr/beginner/saving_loading_models.html#inference
         return instance

--- a/evaluate.py
+++ b/evaluate.py
@@ -11,9 +11,17 @@ from main import get_env
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('env_name', type=str, default='simple_adversary_v2', help='name of the env',
-                        choices=['simple_adversary_v2', 'simple_spread_v2', 'simple_tag_v2'])
+                        choices=['simple_adversary_v2', 
+                                 'simple_crypto_v2',
+                                 'simple_push_v2',
+                                 'simple_reference_v2',
+                                 'simple_speaker_listener_v3',
+                                 'simple_spread_v2', 
+                                 'simple_tag_v2', 
+                                 'simple_world_comm_v2',
+                                 'simple_v2'])
     parser.add_argument('folder', type=str, help='name of the folder where model is saved')
-    parser.add_argument('--episode-num', type=int, default=10, help='total episode num during evaluation')
+    parser.add_argument('--episode-num', type=int, default=5000, help='total episode num during evaluation')
     parser.add_argument('--episode-length', type=int, default=50, help='steps per episode')
 
     args = parser.parse_args()
@@ -44,7 +52,7 @@ if __name__ == '__main__':
             for agent_id, reward in rewards.items():  # update reward
                 agent_reward[agent_id] += reward
 
-        env.close()
+        # env.close()
         message = f'episode {episode + 1}, '
         # episode finishes, record reward
         for agent_id, reward in agent_reward.items():
@@ -52,8 +60,8 @@ if __name__ == '__main__':
             message += f'{agent_id}: {reward:>4f}; '
         print(message)
         # save gif
-        frame_list[0].save(os.path.join(gif_dir, f'out{gif_num + episode + 1}.gif'),
-                           save_all=True, append_images=frame_list[1:], duration=1, loop=0)
+        # frame_list[0].save(os.path.join(gif_dir, f'out{gif_num + episode + 1}.gif'),
+        #                    save_all=True, append_images=frame_list[1:], duration=1, loop=0)
 
     # training finishes, plot reward
     fig, ax = plt.subplots()

--- a/main.py
+++ b/main.py
@@ -3,7 +3,15 @@ import os
 
 import matplotlib.pyplot as plt
 import numpy as np
-from pettingzoo.mpe import simple_adversary_v2, simple_spread_v2, simple_tag_v2
+from pettingzoo.mpe import simple_adversary_v2, \
+                            simple_crypto_v2, \
+                            simple_push_v2, \
+                            simple_reference_v2, \
+                            simple_speaker_listener_v3, \
+                            simple_spread_v2, \
+                            simple_tag_v2, \
+                            simple_world_comm_v2, \
+                            simple_v2
 
 from MADDPG import MADDPG
 
@@ -12,12 +20,25 @@ def get_env(env_name, ep_len=25):
     """create environment and get observation and action dimension of each agent in this environment"""
     new_env = None
     if env_name == 'simple_adversary_v2':
-        new_env = simple_adversary_v2.parallel_env(max_cycles=ep_len)
-    if env_name == 'simple_spread_v2':
-        new_env = simple_spread_v2.parallel_env(max_cycles=ep_len)
-    if env_name == 'simple_tag_v2':
-        new_env = simple_tag_v2.parallel_env(max_cycles=ep_len)
-
+        new_env = simple_adversary_v2.parallel_env(max_cycles=ep_len) # simple_adversary_v2.env(N=2, max_cycles=25, continuous_actions=False)
+    elif env_name == 'simple_crypto_v2':
+        new_env = simple_crypto_v2.parallel_env(max_cycles=ep_len) # simple_crypto_v2.env(max_cycles=25, continuous_actions=False)
+    elif env_name == 'simple_push_v2':
+        new_env = simple_push_v2.parallel_env(max_cycles=ep_len) # simple_push_v2.env(max_cycles=25, continuous_actions=False)
+    elif env_name == 'simple_reference_v2':
+        new_env = simple_reference_v2.parallel_env(max_cycles=ep_len) # simple_reference_v2.env(local_ratio=0.5, max_cycles=25, continuous_actions=False)
+    elif env_name == 'simple_speaker_listener_v3':
+        new_env = simple_speaker_listener_v3.parallel_env(max_cycles=ep_len) # simple_speaker_listener_v3.env(max_cycles=25, continuous_actions=False)
+    elif env_name == 'simple_spread_v2':
+        new_env = simple_spread_v2.parallel_env(max_cycles=ep_len) # simple_spread_v2.env(N=3, local_ratio=0.5, max_cycles=25, continuous_actions=False)
+    elif env_name == 'simple_tag_v2':
+        new_env = simple_tag_v2.parallel_env(max_cycles=ep_len) # simple_tag_v2.env(num_good=1, num_adversaries=3, num_obstacles=2, max_cycles=25, continuous_actions=False)
+    elif env_name == 'simple_world_comm_v2':
+        new_env = simple_world_comm_v2.parallel_env(max_cycles=ep_len) # simple_world_comm.env(num_good=2, num_adversaries=4, num_obstacles=1,
+                                                                        # num_food=2, max_cycles=25, num_forests=2, continuous_actions=False)
+    elif env_name == 'simple_v2':
+        new_env = simple_v2.parallel_env(max_cycles=ep_len) # simple_v2.env(max_cycles=25, continuous_actions=False)
+    
     new_env.reset()
     _dim_info = {}
     for agent_id in new_env.agents:
@@ -30,8 +51,16 @@ def get_env(env_name, ep_len=25):
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
-    parser.add_argument('env_name', type=str, default='simple_adversary_v2', help='name of the env',
-                        choices=['simple_adversary_v2', 'simple_spread_v2', 'simple_tag_v2'])
+    parser.add_argument('env_name', type=str, default='simple_world_comm_v2', help='name of the env',
+                        choices=['simple_adversary_v2', 
+                                 'simple_crypto_v2',
+                                 'simple_push_v2',
+                                 'simple_reference_v2',
+                                 'simple_speaker_listener_v3',
+                                 'simple_spread_v2', 
+                                 'simple_tag_v2', 
+                                 'simple_world_comm_v2',
+                                 'simple_v2'])
     parser.add_argument('--episode_num', type=int, default=30000,
                         help='total episode num during training procedure')
     parser.add_argument('--episode_length', type=int, default=25, help='steps per episode')
@@ -74,7 +103,7 @@ if __name__ == '__main__':
                 action = maddpg.select_action(obs)
 
             next_obs, reward, done, info = env.step(action)
-            # env.render()
+            env.render()
             maddpg.add(obs, action, reward, next_obs, done)
 
             for agent_id, r in reward.items():  # update reward


### PR DESCRIPTION
- `.gitignore` 엔트리 추가
- [PyTorch 튜토리얼](https://tutorials.pytorch.kr/beginner/saving_loading_models.html#inference)에 따르면 model을 로드한 뒤
> 추론을 실행하기 전에 반드시 `model.eval()` 을 호출하여 드롭아웃 및 배치 정규화를 평가 모드로 설정하여야 합니다. 이 과정을 거치지 않으면 일관성 없는 추론 결과가 출력됩니다.
- 라고 되어 있어서 코드를 추가했는데, 코드가 없어도 문제가 없는 것 같아 주석처리 해 놓았음
- [PettingZoo MPE의 모든 환경](https://pettingzoo.farama.org/environments/mpe/)을 사용할 수 있도록 변경
- `evaluate.py`
  - eval할 에피소드 수의 기본값이 10 으로 너무 작아 5000 으로 수정 (`--episode-num` arg로 수동 지정 가능)
  - eval할 때 `env.close()` 때문에 매 에피소드마다 GUI 창이 꺼지는 것을 막기 위해 해당 라인 주석 처리
  - eval할 때 각 에피소드를 gif로 저장하는 부분에서 시간이 꽤 걸려 해당 라인 주석 처리
- `main.py` 에서 학습 시 매 에피소드를 시각적으로 볼 수 있도록 `env.render()` 주석 해제